### PR TITLE
Changing GitHub action to blue/green

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,12 @@ jobs:
         cf_password: ${{ secrets.CF_PASSWORD }}
         cf_org: ${{ secrets.CF_ORG }}
         cf_space: ${{ secrets.CF_SPACE }}
-        command: push 
+        command: push gettingstarted-tim-blue
+    - uses: citizen-of-planet-earth/cf-cli-action@master
+      with:
+        cf_api: ${{ secrets.CF_API }}
+        cf_username: ${{ secrets.CF_USER }}
+        cf_password: ${{ secrets.CF_PASSWORD }}
+        cf_org: ${{ secrets.CF_ORG }}
+        cf_space: ${{ secrets.CF_SPACE }}
+        command: push gettingstarted-tim-green


### PR DESCRIPTION
Change the GitHub action to model a blue/green deployment but pushing the app twice with explicitly chose app names. 